### PR TITLE
Fix minor issue with a installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npm install expo-cli --g
 4. Run the following command to create `AMPLITUDE_KEY` environment variable:
 
    ```sh
-   echo "AMPLITUDE_KEY=test_key" > .env
+   echo "AMPLITUDE_KEY=test_key" >> .env
    ```
 
 5. Create an empty `./google-services.json` file in the root of the application.


### PR DESCRIPTION
# Description

This is a minor fix on a instruction in which previous line in `.env` is replaced, not prepended to next one.